### PR TITLE
add support for swayidle (reopened)

### DIFF
--- a/io.github.slgobinath.SafeEyes.yaml
+++ b/io.github.slgobinath.SafeEyes.yaml
@@ -19,7 +19,7 @@ finish-args:
   - "--talk-name=org.gnome.Mutter.IdleMonitor"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.gnome.SessionManager"
-  - "--system-talk-name=org.freedesktop.login1" # for swayidle
+  - "--system-talk-name=org.freedesktop.login1" # for swayidle and detecting system suspend
 
 cleanup:
   - /cache

--- a/io.github.slgobinath.SafeEyes.yaml
+++ b/io.github.slgobinath.SafeEyes.yaml
@@ -40,6 +40,7 @@ modules:
   - modules/alsa-utils.yml # required for 'audible alert' plugin
   - modules/xprintidle.yml # idle detection other than gnome
   - modules/python3-requirements.yml # auto generated pip dependencies for safeeyes
+  - modules/swayidle.yml # idle detection for wayland protocol ext-idle-notify-v1
 
   - name: safeeyes
     buildsystem: simple

--- a/io.github.slgobinath.SafeEyes.yaml
+++ b/io.github.slgobinath.SafeEyes.yaml
@@ -19,6 +19,7 @@ finish-args:
   - "--talk-name=org.gnome.Mutter.IdleMonitor"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--talk-name=org.gnome.SessionManager"
+  - "--system-talk-name=org.freedesktop.login1" # for swayidle
 
 cleanup:
   - /cache

--- a/modules/swayidle.yml
+++ b/modules/swayidle.yml
@@ -1,0 +1,6 @@
+name: swayidle
+buildsystem: meson
+sources:
+  - type: archive
+    url: "https://github.com/swaywm/swayidle/releases/download/1.8.0/swayidle-1.8.0.tar.gz"
+    sha256: 16b3e76a117f2f0ff2ee5fbebf38849595cdd705db1cd5f6aceaed00d71b3aa1


### PR DESCRIPTION
This is a rebase of #7.
It also drops the workaround commit that was needed for https://github.com/flatpak/xdg-dbus-proxy/issues/21, as that has since been fixed.