### PR TITLE
feat: add do not disturb detection for KDE

### DIFF
--- a/io.github.slgobinath.SafeEyes.yaml
+++ b/io.github.slgobinath.SafeEyes.yaml
@@ -14,6 +14,7 @@ finish-args:
   # various DE support
   - "--talk-name=org.gnome.Mutter.IdleMonitor" # smartpause (gnome)
   - "--talk-name=org.kde.StatusNotifierWatcher" # trayicon (all desktops)
+  - "--talk-name=org.freedesktop.Notifications" # donotdisturb (kde)
   - "--talk-name=org.gnome.SessionManager" # donotdisturb (gnome)
   - "--talk-name=org.gnome.ScreenSaver" # for screensaver plugin (gnome)
   - "--talk-name=org.freedesktop.ScreenSaver" # for screensaver plugin (kde)


### PR DESCRIPTION
Needs to be able to check `org.freedesktop.Notifications.Inhibited` to know whether do  not disturb is enabled on KDE Plasma.

Resolves https://github.com/flathub/io.github.slgobinath.SafeEyes/issues/64